### PR TITLE
Support API key and secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Third, this stuff:
 ```ruby
 client = Bitstampede::Client.new
 
-# I am sad for the following, but such is Bitstamp at present :-\
-client.key = 'YOUR_USER_ID'
-client.secret = 'YOUR_PASSWORD'
+client.key = 'YOUR_API_KEY
+client.secret = 'YOUR_API_SECRET'
+client.client_id = 'YOUR_CLIENT_ID'
 
 # Alternatively, you can configure the client on initialization with:
-client = Bitstampede::Client.new('YOUR_USER_ID', 'YOUR_PASSWORD')
+client = Bitstampede::Client.new('YOUR_API_KEY', 'YOUR_API_SECRET', 'YOUR_CLIENT_ID')
 
 # Fetch your balance
 client.balance

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ client.secret = 'YOUR_API_SECRET'
 client.client_id = 'YOUR_CLIENT_ID'
 
 # Alternatively, you can configure the client on initialization with:
-client = Bitstampede::Client.new('YOUR_API_KEY', 'YOUR_API_SECRET', 'YOUR_CLIENT_ID')
+client = Bitstampede::Client.new(key: 'YOUR_API_KEY', secret: 'YOUR_API_SECRET', client_id: 'YOUR_CLIENT_ID')
 
 # Fetch your balance
 client.balance

--- a/bitstampede.gemspec
+++ b/bitstampede.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", '2.14.0.rc1'
+  spec.add_development_dependency "rspec", '2.14.1'
   spec.add_development_dependency "fakeweb"
   spec.add_development_dependency "pry"
 end

--- a/lib/bitstampede/client.rb
+++ b/lib/bitstampede/client.rb
@@ -6,10 +6,10 @@ module Bitstampede
   class Client
     attr_accessor :key, :secret, :client_id
 
-    def initialize(key = nil, secret = nil, client_id = nil)
-      @key       = key
-      @secret    = secret
-      @client_id = client_id
+    def initialize(options = {})
+      @key       = options[:key]
+      @secret    = options[:secret]
+      @client_id = options[:client_id]
     end
 
     def balance

--- a/lib/bitstampede/client.rb
+++ b/lib/bitstampede/client.rb
@@ -4,12 +4,12 @@ require 'bigdecimal/util'
 
 module Bitstampede
   class Client
-    attr_accessor :key
-    attr_accessor :secret
+    attr_accessor :key, :secret, :client_id
 
-    def initialize(key = nil, secret = nil)
-      @key    = key
-      @secret = secret
+    def initialize(key = nil, secret = nil, client_id = nil)
+      @key       = key
+      @secret    = secret
+      @client_id = client_id
     end
 
     def balance

--- a/lib/bitstampede/nonce_generator.rb
+++ b/lib/bitstampede/nonce_generator.rb
@@ -1,0 +1,8 @@
+module Bitstampede
+  class NonceGenerator
+    def generate
+      t = Time.now
+      t.to_i.to_s + t.usec.to_s[0..1]
+    end
+  end
+end

--- a/spec/unit/bitstampede/client_spec.rb
+++ b/spec/unit/bitstampede/client_spec.rb
@@ -16,7 +16,7 @@ describe Bitstampede::Client do
     end
 
     it 'allows specifying key/secret on initialize' do
-      client = described_class.new('KEY', 'SECRET')
+      client = described_class.new(key: 'KEY', secret: 'SECRET', client_id: "client-id")
 
       expect(client.key).to eql('KEY')
       expect(client.secret).to eql('SECRET')

--- a/spec/unit/bitstampede/net_spec.rb
+++ b/spec/unit/bitstampede/net_spec.rb
@@ -5,8 +5,9 @@ describe Bitstampede::Net do
   subject(:net) { described_class.new(client) }
 
   before do
-    client.stub(:secret).and_return(1)
-    client.stub(:key).and_return(2)
+    client.stub(:secret).and_return('secret')
+    client.stub(:key).and_return('key')
+    client.stub(:client_id).and_return('1234')
   end
 
   it 'gets instantiated with a client' do
@@ -14,14 +15,16 @@ describe Bitstampede::Net do
   end
 
   it 'defers to its client for secret' do
-    expect(net.secret).to eq(1)
+    expect(net.secret).to eq('secret')
   end
 
   it 'defers to its client for key' do
-    expect(net.key).to eq(2)
+    expect(net.key).to eq('key')
   end
 
   describe '#post' do
+    let(:hmac) { double("hmac", :hexdigest => "hexdigest") }
+
     describe 'any_endpoint' do
       let(:example_balance) do
         <<-JSON
@@ -32,11 +35,19 @@ describe Bitstampede::Net do
       end
 
       before do
+        OpenSSL::HMAC.stub(:new).with('secret', OpenSSL::Digest::SHA256.new){ hmac }
+        Bitstampede::NonceGenerator.stub(:new) { double(:generate => "magical nonce") }
         FakeWeb.register_uri(:post, "https://www.bitstamp.net/api/balance/", body: example_balance)
+        hmac.stub(:update) { hmac }
       end
 
       it "queries the appropriate endpoint and returns its body as a string" do
         expect(json_parse(net.post('balance'))).to eq(json_parse(example_balance))
+      end
+
+      it "generates a signature" do
+        json_parse(net.post('balance'))
+        expect(hmac).to have_received(:update).with("magical nonce1234key")
       end
     end
   end


### PR DESCRIPTION
These changes are incompatible with the previous username/password
authentication implementation
